### PR TITLE
[FIX] Overriding ir.http's binary_content to point method directly to attachment

### DIFF
--- a/product_configurator_wizard/models/__init__.py
+++ b/product_configurator_wizard/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import sale
+from . import ir_http

--- a/product_configurator_wizard/models/ir_http.py
+++ b/product_configurator_wizard/models/ir_http.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models
+from openerp.http import request
+
+from ..wizard.product_configurator import ProductConfigurator as configurator
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def binary_content(
+            self, xmlid=None, model='ir.attachment', id=None,
+            field='datas', unique=False, filename=None,
+            filename_field='datas_fname', download=False,
+            mimetype=None,
+            default_mimetype='application/octet-stream', env=None):
+        env = env or request.env
+        # get object and content
+        obj = None
+        if xmlid:
+            obj = env.ref(xmlid, False)
+        elif id and model in env.registry:
+            obj = env[model].browse(int(id))
+
+        if str(obj._model) == 'product.configurator':
+            attachment = obj.custom_value_ids.filtered(
+                lambda x: x.attribute_id.id == int(field.split(
+                    configurator.custom_field_prefix)[1])
+            ).attachment_ids[0]
+            id = attachment.id
+            model = 'ir.attachment'
+            field = 'datas'
+        return super(IrHttp, self).binary_content(
+            xmlid=xmlid, model=model, id=id, field=field,
+            unique=unique, filename=filename, filename_field=filename_field,
+            download=download, mimetype=mimetype,
+            default_mimetype=default_mimetype, env=env
+        )


### PR DESCRIPTION
@tv-openbig while this is a nasty hack, I will leave it as PR so you can use it as a workaround for issue #8 until a better solution comes up.

It's a problem that persists in Odoo as well. for example, try the import Translation wizard, set a file and try saving it right after.