### PR TITLE
Custom values from Wizard

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -288,6 +288,7 @@ class ProductTemplate(models.Model):
                     'attachment_ids': [(6, 0, val.ids)]
                 })
             else:
+                self.env['product.attribute'].browse(key).validate_custom_val(val)
                 custom_vals.update({'value': val})
             custom_lines.append((0, 0, custom_vals))
         return custom_lines

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -275,7 +275,7 @@ class ProductTemplate(models.Model):
             :param custom_values: dict {product.attribute.id: custom_value}
 
             :returns: list of custom values compatible with write and create
-         """
+        """
         binary_attribute_ids = self.env['product.attribute'].search([
             ('custom_type', '=', 'binary')]).ids
 

--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -276,8 +276,6 @@ class ProductTemplate(models.Model):
 
             :returns: list of custom values compatible with write and create
          """
-        custom_values = custom_values or {}
-
         binary_attribute_ids = self.env['product.attribute'].search([
             ('custom_type', '=', 'binary')]).ids
 

--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -2,6 +2,7 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from ast import literal_eval
 
 # TODO: Implement a default attribute value field/method to load up on wizard
 
@@ -100,6 +101,19 @@ class ProductAttribute(models.Model):
                   self.custom_type)
             )
 
+    def validate_custom_val(self, val):
+        """ Pass in a desired custom value and ensure it is valid.
+        Probaly should check type, etc, but let's assume fine for the moment.
+        """ 
+        self.ensure_one()
+        if self.custom_type in ('int', 'float'):
+            if self.min_val or self.max_val:
+                val = literal_eval(val)
+                if val < self.min_val or val > self.max_val:
+                    raise ValidationError(
+                        _("Selected custom value '%s' must be between %s and %s" %
+                          (self.name, self.min_val, self.max_val))
+                    )
 
 class ProductAttributeLine(models.Model):
     _inherit = 'product.attribute.line'

--- a/product_configurator_wizard/models/sale.py
+++ b/product_configurator_wizard/models/sale.py
@@ -23,7 +23,8 @@ class SaleOrderLine(models.Model):
         wizard_obj = self.env['product.configurator']
         wizard = wizard_obj.create({
             'product_id': self.product_id.id,
-            'state': active_step
+            'state': active_step,
+            'order_line_id': self.id,
         })
 
         return {

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -627,11 +627,13 @@ class ProductConfigurator(models.TransientModel):
             field_name = self.field_prefix + str(attr_id)
             custom_field_name = self.custom_field_prefix + str(attr_id)
 
-            if field_name not in vals:
+            if field_name not in vals and custom_field_name not in vals:
                 continue
 
             # Add attribute values from the client except custom attribute
-            if vals[field_name] != custom_val.id:
+            # If a custom value is being written, but field name is not in
+            #   the write dictionary, then it must be a custom value!
+            if vals.get(field_name, custom_val.id) != custom_val.id:
                 if attr_line.multi and isinstance(vals[field_name], list):
                     if not vals[field_name]:
                         field_val = None
@@ -660,7 +662,8 @@ class ProductConfigurator(models.TransientModel):
                 })
 
             # Remove dynamic field from value list to prevent error
-            del vals[field_name]
+            if field_name in vals:
+                del vals[field_name]
             if custom_field_name in vals:
                 del vals[custom_field_name]
 

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -783,7 +783,8 @@ class ProductConfigurator(models.TransientModel):
         if self.product_id:
             self.product_id.write({
                 'attribute_value_ids': [(6, 0, self.value_ids.ids)],
-                'value_custom_ids': [(6, 0, custom_vals)]
+                'value_custom_ids': map(lambda cv: (2, cv), self.product_id.value_custom_ids.ids) + \
+                                        self.product_id.product_tmpl_id.encode_custom_values(custom_vals),
             })
             self.unlink()
             return

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -653,6 +653,10 @@ class ProductConfigurator(models.TransientModel):
                 attr_val_dict.update({
                     attr_id: field_val
                 })
+                # Ensure there is no custom value stored if we have switched from custom 
+                # to chosen value.
+                if attr_line.custom:
+                    custom_val_dict.update({attr_id: False})
             elif attr_line.custom:
                 # For non-binary fields, a custom field value may have been entered which
                 # is 0 or some other way False, and this will not be in the dictionary of

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -650,7 +650,10 @@ class ProductConfigurator(models.TransientModel):
                     attr_id: field_val
                 })
             elif attr_line.custom:
-                val = vals[custom_field_name]
+                # For non-binary fields, a custom field value may have been entered which
+                # is 0 or some other way False, and this will not be in the dictionary of
+                # values, so need to assume that if not passed it is a "False" value desired.
+                val = vals.get(custom_field_name, False)
                 if attr_line.attribute_id.custom_type == 'binary':
                     # TODO: Add widget that enables multiple file uploads
                     val = [{

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -799,10 +799,11 @@ class ProductConfigurator(models.TransientModel):
         }
 
         if self.product_id:
+            remove_cv_links = map(lambda cv: (2, cv), self.product_id.value_custom_ids.ids)
+            new_cv_links = self.product_id.product_tmpl_id.encode_custom_values(custom_vals)
             self.product_id.write({
                 'attribute_value_ids': [(6, 0, self.value_ids.ids)],
-                'value_custom_ids': map(lambda cv: (2, cv), self.product_id.value_custom_ids.ids) + \
-                                        self.product_id.product_tmpl_id.encode_custom_values(custom_vals),
+                'value_custom_ids':  remove_cv_links + new_cv_links,
             })
             if self.order_line_id:
                 self.order_line_id.write(self._extra_line_values(self.order_line_id.order_id,

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -794,9 +794,19 @@ class ProductConfigurator(models.TransientModel):
             })
             self.unlink()
             return
+        #
+        # This try except is too generic.
+        # The create_variant routine could effectively fail for
+        # a large number of reasons, including bad programming.
+        # It should be refactored.
+        # In the meantime, at least make sure that a validation
+        # error legitimately raised in a nested routine
+        # is passed through.
         try:
             variant = self.product_tmpl_id.create_variant(
                 self.value_ids.ids, custom_vals)
+        except ValidationError:
+            raise
         except:
             raise ValidationError(
                 _('Invalid configuration! Please check all '


### PR DESCRIPTION
Wizard was not translating custom values correctly after reconfiguring.

New method created to allow this to happen, and wizard changed to use this method.