### PR TITLE
[FIX] Add support for the sale_margin module

### DIFF
--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -792,8 +792,10 @@ class ProductConfigurator(models.TransientModel):
         created or edited lines."""
         vals = {}
         if new:
-            vals.update({'name': product.display_name})
-            vals.update({'product_uom': product.uom_id.id})
+            vals.update({
+                'name': product.display_name,
+                'product_uom': product.uom_id.id,
+            })
         return vals
 
     @api.multi

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -793,6 +793,7 @@ class ProductConfigurator(models.TransientModel):
         vals = {}
         if new:
             vals.update({'name': product.display_name})
+            vals.update({'product_uom': product.uom_id.id})
         return vals
 
     @api.multi


### PR DESCRIPTION
Adding configured sales order lines fails when sale_margin module is installed.
The sale_margin module requires the sales order line to include product_uom:
odoo/addons/sale_margin/models/sale_order.py