### PR TITLE
[FIX] Wizard Attributes

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -457,6 +457,9 @@ class ProductTemplate(models.Model):
         if custom_vals is None:
             custom_vals = {}
 
+        # Check if all the values passed are not restricted
+        avail_val_ids = self.values_available(value_ids, value_ids)
+
         for line in self.attribute_line_ids:
             # Validate custom values
             attr = line.attribute_id
@@ -466,11 +469,12 @@ class ProductTemplate(models.Model):
                 common_vals = set(value_ids) & set(line.value_ids.ids)
                 custom_val = custom_vals.get(attr.id)
                 if line.required and not common_vals and not custom_val:
-                    # TODO: Verify custom value type to be correct
-                    return False
+                    # If there are possible values, then enforce
+                    # the "required" status.
+                    if set(line.value_ids.ids) & set(avail_val_ids):
+                        # TODO: Verify custom value type to be correct
+                        return False
 
-        # Check if all all the values passed are not restricted
-        avail_val_ids = self.values_available(value_ids, value_ids)
         if set(value_ids) - set(avail_val_ids):
             return False
 

--- a/product_configurator_wizard/tests/__init__.py
+++ b/product_configurator_wizard/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import test_wizard
+from . import test_wizard_attrs

--- a/product_configurator_wizard/tests/test_wizard.py
+++ b/product_configurator_wizard/tests/test_wizard.py
@@ -23,11 +23,13 @@ class ConfigurationRules(TransactionCase):
 
         return attr_vals
 
-    def get_wizard_write_dict(self, wizard, attr_values):
+    def get_wizard_write_dict(self, wizard, attr_values, remove_values=None):
         """Turn a series of attribute.value objects to a dictionary meant for
         writing values to the product.configurator wizard"""
 
         write_dict = {}
+        if remove_values is None:
+            remove_values = []
 
         multi_attr_ids = wizard.product_tmpl_id.attribute_line_ids.filtered(
             lambda x: x.multi).mapped('attribute_id').ids
@@ -39,6 +41,10 @@ class ConfigurationRules(TransactionCase):
                 write_dict[field_name][0][2].append(val.id)
                 continue
             write_dict.update({field_name: val.id})
+
+        for val in remove_values:
+            field_name = wizard.field_prefix + str(val.attribute_id.id)
+            write_dict.update({field_name: False})
 
         return write_dict
 
@@ -53,6 +59,10 @@ class ConfigurationRules(TransactionCase):
 
     def test_wizard_configuration(self):
         """Test product configurator wizard"""
+
+        config_variants = self.env['product.product'].search([
+            ('config_ok', '=', True)
+        ])
 
         # Start a new configuration wizard
         wizard_obj = self.env['product.configurator'].with_context({
@@ -87,37 +97,66 @@ class ConfigurationRules(TransactionCase):
 
         wizard.action_next_step()
 
-        config_variants = self.env['product.product'].search([
+        new_config_variants = self.env['product.product'].search([
             ('config_ok', '=', True)
         ])
 
-        self.assertTrue(len(config_variants) == 1,
+        self.assertTrue(len(new_config_variants - config_variants) == 1,
                         "Wizard did not create a configurable variant")
 
-    def test_reconfiguration(self):
-        """Test reconfiguration functionality of the wizard"""
-        self.test_wizard_configuration()
-
-        order_line = self.so.order_line.filtered(
-            lambda l: l.product_id.config_ok
-        )
-
+    def do_reconfigure(self, order_line, attr_vals):
         reconfig_action = order_line.reconfigure_product()
 
         wizard = self.env['product.configurator'].browse(
             reconfig_action.get('res_id')
         )
 
-        attr_vals = self.get_attr_values(['diesel', '220d'])
         self.wizard_write_proceed(wizard, attr_vals)
 
-        # Cycle through steps until wizard ends
-        while wizard.action_next_step():
-            pass
+        # if wizard only had one step, it would already have completed
+        if wizard.exists():
+            # Cycle through steps until wizard ends
+            while wizard.action_next_step():
+                pass
 
+    def test_reconfiguration(self):
+        """Test reconfiguration functionality of the wizard"""
         config_variants = self.env['product.product'].search([
             ('config_ok', '=', True)
         ])
 
-        self.assertTrue(len(config_variants) == 2,
+        self.test_wizard_configuration()
+
+        existing_lines = self.so.order_line
+
+        order_line = self.so.order_line.filtered(
+            lambda l: l.product_id.config_ok
+        )
+
+        self.do_reconfigure(order_line,
+                            self.get_attr_values(['diesel', '220d'])
+                            )
+
+        new_config_variants = self.env['product.product'].search([
+            ('config_ok', '=', True)
+        ])
+
+        self.assertTrue(len(new_config_variants - config_variants) == 2,
                         "Wizard reconfiguration did not create a new variant")
+
+        created_line = self.so.order_line - existing_lines
+        self.assertTrue(len(created_line) == 0,
+                        "Wizard created an order line on reconfiguration")
+
+        # test that running through again with the same values does not
+        # create another variant
+        self.do_reconfigure(order_line,
+                            self.get_attr_values(['diesel', '220d'])
+                            )
+
+        new_config_variants = self.env['product.product'].search([
+            ('config_ok', '=', True)
+        ])
+
+        self.assertTrue(len(new_config_variants - config_variants) == 2,
+                        "Wizard reconfiguration created a redundant variant")

--- a/product_configurator_wizard/tests/test_wizard_attrs.py
+++ b/product_configurator_wizard/tests/test_wizard_attrs.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+
+from odoo.addons.product_configurator_wizard.tests.test_wizard \
+    import ConfigurationRules
+
+
+class ConfigurationAttributes(ConfigurationRules):
+
+    def setUp(self):
+        """
+        Product with 3 sizes:
+            Small or Medium allow Blue or Red, but colour is optional
+            Large does not allow colour selection
+        """
+        super(ConfigurationAttributes, self).setUp()
+
+        self.attr_size = self.env['product.attribute'].create(
+            {'name': 'Size'})
+        self.attr_val_small = self.env['product.attribute.value'].create(
+            {'attribute_id': self.attr_size.id,
+             'name': 'Small',
+             }
+        )
+        self.attr_val_med = self.env['product.attribute.value'].create(
+            {'attribute_id': self.attr_size.id,
+             'name': 'Medium',
+             }
+        )
+        self.attr_val_large = self.env['product.attribute.value'].create(
+            {'attribute_id': self.attr_size.id,
+             'name': 'Large (Green)',
+             }
+        )
+        domain_small_med = self.env['product.config.domain'].create(
+            {'name': 'Small/Med',
+             'domain_line_ids': [
+                 (0, 0, {'attribute_id': self.attr_size.id,
+                         'condition': 'in',
+                         'operator': 'and',
+                         'value_ids':
+                             [(6, 0,
+                               [self.attr_val_small.id, self.attr_val_med.id]
+                               )]
+                         }),
+                 ],
+             }
+        )
+        self.attr_colour = self.env['product.attribute'].create(
+            {'name': 'Colour'})
+        self.attr_val_blue = self.env['product.attribute.value'].create(
+            {'attribute_id': self.attr_colour.id,
+             'name': 'Blue',
+             }
+        )
+        self.attr_val_red = self.env['product.attribute.value'].create(
+            {'attribute_id': self.attr_colour.id,
+             'name': 'Red',
+             }
+        )
+        self.product_temp = self.env['product.template'].create(
+            {'name': 'Config Product',
+             'config_ok': True,
+             'type': 'product',
+             'categ_id': self.env['ir.model.data'].xmlid_to_res_id(
+                 'product.product_category_5'
+             ),
+             'attribute_line_ids': [
+                 (0, 0, {'attribute_id': self.attr_size.id,
+                         'value_ids': [
+                             (6, 0, self.attr_size.value_ids.ids),
+                             ],
+                         'required': True,
+                         }),
+                 (0, 0, {'attribute_id': self.attr_colour.id,
+                         'value_ids': [
+                             (6, 0, self.attr_colour.value_ids.ids),
+                             ],
+                         'required': False,
+                         })
+                 ],
+             }
+        )
+        colour_line = self.product_temp.attribute_line_ids.filtered(
+            lambda a: a.attribute_id == self.attr_colour)
+        self.env['product.config.line'].create({
+            'product_tmpl_id': self.product_temp.id,
+            'attribute_line_id': colour_line.id,
+            'value_ids': [(6, 0, self.attr_colour.value_ids.ids)],
+            'domain_id': domain_small_med.id,
+            })
+
+    def test_configurations_option_or_not_reqd(self):
+        # Start a new configuration wizard
+        wizard_obj = self.env['product.configurator'].with_context({
+            'active_model': 'sale.order',
+            'active_id': self.so.id
+            # 'default_order_id': self.so.id
+        })
+
+        wizard = wizard_obj.create({'product_tmpl_id': self.product_temp.id})
+        wizard.action_next_step()
+
+        dynamic_fields = {}
+        for attribute_line in self.product_temp.attribute_line_ids:
+            field_name = '%s%s' % (
+                wizard.field_prefix,
+                attribute_line.attribute_id.id
+            )
+            dynamic_fields[field_name] = [] if attribute_line.multi else False
+        field_name_colour = '%s%s' % (
+            wizard.field_prefix,
+            self.attr_colour.id
+        )
+        ro_name_colour = '%s%s' % (
+            wizard.ro_field_prefix,
+            self.attr_colour.id
+        )
+        reqd_name_colour = '%s%s' % (
+            wizard.ro_field_prefix,
+            self.attr_colour.id
+        )
+
+        # Define small without colour specified
+        self.wizard_write_proceed(wizard, [self.attr_val_small])
+        new_variant = self.product_temp.product_variant_ids
+        self.assertTrue(len(new_variant) == 1 and
+                        set(new_variant.attribute_value_ids.ids) ==
+                        set([self.attr_val_small.id]),
+                        "Wizard did not accurately create a variant with "
+                        "optional value undefined")
+        config_variants = self.product_temp.product_variant_ids
+
+        order_line = self.so.order_line.filtered(
+            lambda l: l.product_id.config_ok
+        )
+
+        # Redefine to medium without colour
+        self.do_reconfigure(order_line, [self.attr_val_med])
+        new_variant = self.product_temp.product_variant_ids - config_variants
+        self.assertTrue(len(new_variant) == 1 and
+                        set(new_variant.attribute_value_ids.ids) ==
+                        set([self.attr_val_med.id]),
+                        "Wizard did not accurately reconfigure a variant with "
+                        "optional value undefined")
+        config_variants = self.product_temp.product_variant_ids
+
+        # Redefine to medium blue
+        self.do_reconfigure(order_line, [self.attr_val_blue])
+        new_variant = self.product_temp.product_variant_ids - config_variants
+        self.assertTrue(len(new_variant) == 1 and
+                        set(new_variant.attribute_value_ids.ids) ==
+                        set([self.attr_val_med.id, self.attr_val_blue.id]),
+                        "Wizard did not accurately reconfigure a variant with "
+                        "to add an optional value")
+        config_variants = self.product_temp.product_variant_ids
+
+        # Redefine to large - should remove colour, as this is invalid
+        reconfig_action = order_line.reconfigure_product()
+        wizard = self.env['product.configurator'].browse(
+            reconfig_action.get('res_id')
+        )
+        attr_large_dict = self.get_wizard_write_dict(wizard,
+                                                     [self.attr_val_large])
+        attr_blue_dict = self.get_wizard_write_dict(wizard,
+                                                    [self.attr_val_blue])
+        oc_vals = dynamic_fields.copy()
+        oc_vals.update({'id': wizard.id})
+        oc_vals.update(dict(attr_blue_dict, **attr_large_dict))
+        oc_result = wizard.onchange(
+            oc_vals,
+            attr_large_dict.keys()[0],
+            {}
+        )
+        self.assertTrue(field_name_colour in oc_result['value'] and
+                        not oc_result['value'][field_name_colour],
+                        "Colour should have been cleared by wizard"
+                        )
+        self.assertTrue(ro_name_colour in oc_result['value'] and
+                        oc_result['value'][ro_name_colour],
+                        "Colour should have become readonly"
+                        )
+        self.assertTrue(oc_result['value'].get(reqd_name_colour),
+                        "Colour should not have become required"
+                        )
+
+        vals = self.get_wizard_write_dict(wizard, [self.attr_val_large],
+                                          remove_values=[self.attr_val_blue])
+        wizard.write(vals)
+        wizard.action_next_step()
+        if wizard.exists():
+            while wizard.action_next_step():
+                pass
+        new_variant = self.product_temp.product_variant_ids - config_variants
+        self.assertTrue(len(new_variant) == 1 and
+                        set(new_variant.attribute_value_ids.ids) ==
+                        set([self.attr_val_large.id]),
+                        "Wizard did not accurately reconfigure a variant "
+                        "to remove invalid attribute")

--- a/product_configurator_wizard/tests/test_wizard_attrs.py
+++ b/product_configurator_wizard/tests/test_wizard_attrs.py
@@ -199,6 +199,7 @@ class ConfigurationAttributes(ConfigurationRules):
                         "to remove invalid attribute")
 
         # Now test reqd attribute changes.
+        last_variant = new_variant
         self.template_colour_line.write({'required': True})
 
         # Redefine to medium - should make colour required
@@ -219,3 +220,14 @@ class ConfigurationAttributes(ConfigurationRules):
         self.assertTrue(oc_result['value'].get(reqd_name_colour),
                         "Colour should have become required"
                         )
+        # Redefine to large - should make colour not required, despite master
+        # file
+        vals = self.get_wizard_write_dict(wizard, [self.attr_val_large])
+        wizard.write(vals)
+        wizard.action_next_step()
+        if wizard.exists():
+            while wizard.action_next_step():
+                pass
+        self.assertTrue(order_line.product_id == last_variant,
+                        "Wizard did not end up with the same "
+                        "variant")

--- a/product_configurator_wizard/wizard/product_configurator.py
+++ b/product_configurator_wizard/wizard/product_configurator.py
@@ -309,7 +309,6 @@ class ProductConfigurator(models.TransientModel):
 
         # Get the wizard object from the database
         wiz = self.browse(wizard_id)
-        active_step_id = wiz.state
 
         # If the product template is not set it is still at the 1st step
         if not wiz.product_tmpl_id:

--- a/product_configurator_wizard/wizard/product_configurator_view.xml
+++ b/product_configurator_wizard/wizard/product_configurator_view.xml
@@ -21,6 +21,7 @@
                                     <field name="multi"/>
                                 </tree>
                             </field>
+                            <field name="stored_support_vals" invisible='1'/>
                         </group>
                         <group colspan="1">
                             <field attrs="{'invisible': [('product_img', '=', False)]}" name="product_img" readonly="1" nolabel="1" widget="image"/>


### PR DESCRIPTION
If accepted, this would replace the PRs #88 and #97 

Wizard attributes (readonly, required, invisible) now controlled
by 3 virtual fields each, allowing far greater control.  This fixes
a number of issues:

* Attributes with conditional domains might be required, or might
    not be
* Attributes with conditional domains marked as required can now
    be validated if the domain is empty.
* Readonly values can be better detected when the values are not
    passed from the front end.
* Super complex domains can now be used to drive the readonly
    and required values, ands and ors and inherited, as the
    driver is now purely the list of valid ids.
* Easier modification of behaviour in custom circumstances
    with inheritance possible to drive these virtual columns.