### PR TITLE
[FIX] MRP BOM creation

### DIFF
--- a/product_configurator_mrp/models/product.py
+++ b/product_configurator_mrp/models/product.py
@@ -61,7 +61,7 @@ class ProductProduct(models.Model):
             for attr_value in variant.attribute_value_ids:
                 bom_line_vals = attr_value.bom_line_dictionary()
                 if bom_line_vals:
-                    line_vals.append([(0, 0, bom_line_vals)])
+                    line_vals.append((0, 0, bom_line_vals))
 
             Mrp_bom.create(values)
 


### PR DESCRIPTION
The configurator was creating a new BOM, every time
a configuration was retrieved!  Routine now only
creates a BOM if there is none.

Also, refactored to allow for overriding and hooks.
This allows custom code to create a default BOM before
the attributes are added, and for more clever adding
of products (quantities, etc).