### PR TITLE
[FIX] related value on so line is readonly

### DIFF
--- a/product_configurator_wizard/models/sale.py
+++ b/product_configurator_wizard/models/sale.py
@@ -8,7 +8,8 @@ class SaleOrderLine(models.Model):
 
     config_ok = fields.Boolean(
         related='product_id.config_ok',
-        string="Configurable"
+        string="Configurable",
+        readonly=True
     )
 
     @api.multi


### PR DESCRIPTION
The related "config_ok" value on the line is set to readonly
to stop the ORM from attempting an update in case users
do not have write access to product.product.