### PR TITLE
[10] Bug fix: use the right default product UOM

### DIFF
--- a/product_configurator_mrp/models/product.py
+++ b/product_configurator_mrp/models/product.py
@@ -24,6 +24,7 @@ class ProductTemplate(models.Model):
         values = {
             'product_tmpl_id': self.id,
             'product_id': variant.id,
+            'product_uom_id': variant.uom_id.id,
             'bom_line_ids': line_vals
         }
 


### PR DESCRIPTION
I @PCatinean,

I propose to add this line to use the variant unit of mesure in the generated BOM instead of the default UOM of the system