### PR TITLE
[FIX] fix singleton for double click on website and name not defined error in backend

### DIFF
--- a/product_configurator/models/product.py
+++ b/product_configurator/models/product.py
@@ -3,7 +3,6 @@
 from odoo.tools.misc import formatLang
 from odoo.exceptions import ValidationError
 from odoo import models, fields, api, tools, _
-from lxml import etree
 
 
 class ProductTemplate(models.Model):
@@ -621,33 +620,6 @@ class ProductProduct(models.Model):
     _constraints = [
         (_check_attribute_value_ids, None, ['attribute_value_ids'])
     ]
-
-    @api.model
-    def fields_view_get(self, view_id=None, view_type='form',
-                        toolbar=False, submenu=False):
-        """ For configurable products switch the name field with the config_name
-            so as to keep the view intact in whatever form it is at the moment
-            of execution and not duplicate the original just for the sole
-            purpose of displaying the proper name"""
-        res = super(ProductProduct, self).fields_view_get(
-            view_id=view_id, view_type=view_type,
-            toolbar=toolbar, submenu=submenu
-        )
-        if self.env.context.get('default_config_ok'):
-            xml_view = etree.fromstring(res['arch'])
-            xml_name = xml_view.xpath("//field[@name='name']")
-            xml_label = xml_view.xpath("//label[@for='name']")
-            if xml_name:
-                xml_name[0].attrib['name'] = 'config_name'
-                if xml_label:
-                    xml_label[0].attrib['for'] = 'config_name'
-                view_obj = self.env['ir.ui.view']
-                xarch, xfields = view_obj.postprocess_and_fields(self._name,
-                                                                 xml_view,
-                                                                 view_id)
-                res['arch'] = xarch
-                res['fields'] = xfields
-        return res
 
     # TODO: Implement naming method for configured products
     # TODO: Provide a field with custom name in it that defaults to a name

--- a/product_configurator/views/product_view.xml
+++ b/product_configurator/views/product_view.xml
@@ -121,6 +121,19 @@
                     </field> -->
                 </page>
             </xpath>
+            <xpath expr="//field[@name='name']" position="attributes">
+                <attribute name="invisible">context.get('default_config_ok')</attribute>
+            </xpath>
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="config_name" placeholder="Product Name" invisible="not context.get('default_config_ok')"/>
+            </xpath>
+            <xpath expr="//label[@for='name']" position="attributes">
+                <attribute name="invisible">context.get('default_config_ok')</attribute>
+            </xpath>
+            <xpath expr="//label[@for='name']" position="after">
+                <label class="oe_edit_only" for="config_name" string="Product Name" invisible="not context.get('default_config_ok')"/>
+            </xpath>
+
         </field>
     </record>
 

--- a/website_product_configurator/controllers/main.py
+++ b/website_product_configurator/controllers/main.py
@@ -529,7 +529,7 @@ class WebsiteProductConfig(http.Controller):
 
             cfg_session = cfg_session_obj.sudo().create(vals)
 
-        return cfg_session
+        return cfg_session[:1]
 
     def get_config_image(self, product_tmpl, value_ids, size=None):
         """


### PR DESCRIPTION
basically, 2 bugs have been solved. 
1.  singleton for double click on the website because it was creating 2 product config session for the same product, a user in draft/ so at the end it was failing to load product view on the website. because there were 2 sessions and code is handling just for one

2. in the configurable variant in backend there was an error for Name not defined. because from fields_view_get based on the context we were replacing the name field to config_name and original name field has been removed. to Fix this we have just added a config_name field in the view. and make the name and config_name field visible based on context. 
