### PR TITLE
[FIX]product_configurator : fix issue- IndexError: tuple index out of range.

### DIFF
--- a/product_configurator/models/product_config.py
+++ b/product_configurator/models/product_config.py
@@ -43,11 +43,12 @@ class ProductConfigDomain(models.Model):
                      line.value_ids.ids)
                 )
             # ensure 2 operands follow the last operator
-            computed_domain.append(
-                (lines[-1].attribute_id.id,
-                 lines[-1].condition,
-                 lines[-1].value_ids.ids)
-            )
+            if lines:
+                computed_domain.append(
+                    (lines[-1].attribute_id.id,
+                     lines[-1].condition,
+                     lines[-1].value_ids.ids)
+                )
         return computed_domain
 
     name = fields.Char(


### PR DESCRIPTION
Impacted versions: 10.0

Steps to reproduce: 
    1) create configurable product-template
    2) add variants
    3) add restriction and keep domain-lines(`RULES`) blank
    4) go to sale > create sale order > and try to configure product created above

Current behaviour: it will raise an error with traceback

 File "/home/shruti/odoo/v10/odoo_product_configurator/git_hub/odoo-product-configurator/product_configurator_wizard/wizard/product_configurator.py", line 735, in action_next_step
    self.value_ids.ids, active_cfg_line_id)
  File "/home/shruti/odoo/v10/odoo_product_configurator/git_hub/odoo-product-configurator/product_configurator/models/product.py", line 90, in get_adjacent_steps
    open_step_lines = self.get_open_step_lines(value_ids)
  File "/home/shruti/odoo/v10/odoo_product_configurator/git_hub/odoo-product-configurator/product_configurator/models/product.py", line 68, in get_open_step_lines
    value_ids)
  File "/home/shruti/odoo/v10/odoo_product_configurator/git_hub/odoo-product-configurator/product_configurator/models/product.py", line 433, in values_available
    domains = config_lines.mapped('domain_id').compute_domain()
  File "/home/shruti/odoo/v10/odoo_product_configurator/git_hub/odoo-product-configurator/product_configurator/models/product_config.py", line 47, in compute_domain
    (lines[-1:].attribute_id.id,
  File "/home/shruti/odoo/v10/odoo/odoo/models.py", line 5251, in __getitem__
    return self._browse((self._ids[key],), self.env)
IndexError: tuple index out of range

Expected behaviour: No traceback should be there

