### PR TITLE
 Disable "Duplicate" button in Attribute Value form [v10.0]

### DIFF
--- a/product_configurator/views/product_attribute_view.xml
+++ b/product_configurator/views/product_attribute_view.xml
@@ -81,7 +81,7 @@
         <field name="name">product.config.product.attribute.value.form.view</field>
         <field name="model">product.attribute.value</field>
         <field name="arch" type="xml">
-            <form string="Product Attribute Values">
+            <form string="Product Attribute Values" duplicate="false">
                 <div class="oe_left" style="width: 500px;">
                     <div class="oe_title" style="width: 390px;">
                         <label class="oe_edit_only" for="name" string="Value"/>


### PR DESCRIPTION
We should disable the "Duplicate" button on Product Attribute Value's form view, to prevent user from using the duplicate function.

When you duplicate an attribute value (source attribute value), the new attribute value is added to existing products which have the source attribute value assigned.

Ex: 
1. Source attribute value: Size - XXL on Product Tshirt.
2. Duplicate the Size - XXL(source attribute) --> Size XXS (this new attribute will add to Tshirt )
3. Tshirt Size - XXL will have 2 attributes which are XXL(source attribute) and XXS(new attribute)