### PR TITLE
[13.0][FIX] Error on smart button with context due to javascript of the product_configurator module

### DIFF
--- a/product_configurator/static/js/form_widgets.js
+++ b/product_configurator/static/js/form_widgets.js
@@ -52,7 +52,7 @@ odoo.define('product_configurator.FieldBooleanButton', function (require) {
             var self = this;
             var attrs = event.data.attrs
             if (event.data.attrs.context) {
-                var btn_ctx = pyUtils.eval('context', event.data.attrs.context);
+                var btn_ctx = pyUtils.eval('context', event.data.attrs);
                 var record_ctx = self.model.get(event.data.record.id).context;
                 self.model.localData[event.data.record.id].context = _.extend({}, btn_ctx, record_ctx)
             }


### PR DESCRIPTION
pyUtils.eval('context', event.data.attrs.context) -> the context key is not in "event.data.attrs.context" -> Oddo client error when user clic on smart button (for instance, the button "Forecasted" on the product form or the "Partner Ledger" on the contact form)